### PR TITLE
「✨」 feat: added default session option && 「🔨」 fix: fixed issue #1 where a invisible option was shown (fixes #1)

### DIFF
--- a/cmd/timmy/help.go
+++ b/cmd/timmy/help.go
@@ -12,4 +12,10 @@ func	helpMsg() {
 	fmt.Println("  create - used to create session")
 	fmt.Println("         - '-2' used to create a session named after the last two folder of the working directory")
 	fmt.Println("         - 'name' used to create a session named with the name specified")
+	fmt.Println("         - '-d' used to create a \"default workspace\" (with nvim as first tab and a shell as second)")
+	fmt.Println("  version - used to print version number")
+}
+
+func	versionMsg() {
+	fmt.Println("timmy version v0.1.1")
 }

--- a/cmd/timmy/timmy.go
+++ b/cmd/timmy/timmy.go
@@ -21,5 +21,7 @@ func	main() {
 		ts.Ts()
 	} else if args[1] == "create" {
 		tm.Tm()
+	} else if args[1] == "version" {
+		versionMsg()
 	}
 }

--- a/cmd/tm/tm.go
+++ b/cmd/tm/tm.go
@@ -16,6 +16,8 @@ func	Tm() {
 	if (args[0] == "-2") {
 		tmux.CreateSession(path.GetCurrentPathN(2))
 		return
+	} else if (args[0] == "-d") {
+		 tmux.CreateDefaultSession(path.GetCurrentPathN(1))
 	} else {
 		tmux.CreateSession(args[0])
 	}

--- a/cmd/ts/ts.go
+++ b/cmd/ts/ts.go
@@ -16,7 +16,7 @@ func	Ts() {
 	}
 	str := strings.Split(string(cmd), "\n")
 	res, err := fuzzyfinder.FindMulti(
-		str,
+		str[0:len(str)-1],
 		func(i int) string{
 			return str[i]
 		},

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
 			src = self;
 			pname = "timmy";
 			subPackages = [ "cmd/timmy" ];
-			version = "0.1";
+			version = "0.1.1";
 			vendorHash = "sha256-l/+TXNT7Z/CbnVCzB0B8VA7Fkj+MOOL1s3QHnZkAsUg=";
           };
         }
@@ -44,6 +44,7 @@
               go
               gopls
               inputs.pogit.packages.${pkgs.system}.default
+              self.packages.${pkgs.system}.default
             ];
           };
         }

--- a/util/tmux/CreateSession.go
+++ b/util/tmux/CreateSession.go
@@ -15,3 +15,26 @@ func	 CreateSession(name string) {
 		log.Fatal(err)
 	}
 }
+
+func CreateDefaultSession(name string) {
+	if _, err := os.Stat("flake.nix"); err == nil {
+		createCmd := exec.Command("tmux", "new-session", "-s", name, "nix", "develop", "--command", "nvim", ";", "new-window")
+		createCmd.Stdin = os.Stdin
+		createCmd.Stdout = os.Stdout
+		createCmd.Stderr = os.Stderr
+		if err := createCmd.Run(); err != nil {
+			log.Fatal(err)
+		}
+	} else if os.IsNotExist(err) {
+		createCmd := exec.Command("tmux", "new-session", "-s", name, "nvim", ";", "new-window")
+		createCmd.Stdin = os.Stdin
+		createCmd.Stdout = os.Stdout
+		createCmd.Stderr = os.Stderr
+		if err := createCmd.Run(); err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		// Handle unexpected errors
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Added a default session options (`-d`) to the `create` function, that create a session with two tabs, the first is Neovim and the second is a shell. And if the current directory has a flake, it launches Neovim in `nix develop`.

And fixed issue #1, by just removing the last element of the array.

TODO : need to make the `-d` more customizable